### PR TITLE
Update H587Project1Markdown.Rmd

### DIFF
--- a/H587/H587Project1Markdown.Rmd
+++ b/H587/H587Project1Markdown.Rmd
@@ -51,7 +51,26 @@ strata <- c(list(Total=burn),split(burn,burn$newtrt))
 
 ## Output
 ```{r}
-table1(strata,labels)
+#table1(strata,labels) # original output
+
+df<-as.data.frame(table1(strata,labels)) #change from html table to dataframe
+df[rbind(c(3,3),c(3,4),c(4,3),c(4,4))]<-NA # Set NA's # Set NAs
+df <- df[-c(2,5,8,11,14,19),] # Remove header rows
+rownames(df)<-c() #Remove numbered rownames
+
+#Recreate table
+library(kableExtra)
+kable(df) %>% 
+  kable_classic(html_font = "Arial") %>% #set look and font
+  row_spec(0,bold=T) %>%  #bold header
+  row_spec(1,bold=T, hline_after=TRUE) %>%  #bold header
+  #set Sub headers
+  group_rows(group_label = "Treatment", start_row = 2, end_row = 3) %>%  
+  group_rows(group_label = "Status", start_row = 4, end_row = 5) %>% 
+  group_rows(group_label = "Sex", start_row = 6, end_row = 7) %>% 
+  group_rows(group_label = "Race", start_row = 8, end_row = 9) %>% 
+  group_rows(group_label = "Burn type", start_row = 10, end_row = 13) %>% 
+  group_rows(group_label = "Surface area burned (percent)", start_row = 14, end_row = 15)
 ```
 
 


### PR DESCRIPTION
This is one method of setting in NA values for Treatment NT and ST cells.
This method requires the kableExtra package to imitate the previous formatting that table1 had created.

The html table created by table1 is transformed to a data frame. Once in a data frame, edits can be made to the data frame removed doubled headers, and adding NA values. The data frame is then returned to previous formatting via the kableExtra package. There are slight differences in formatting that I have not yet found changes for.